### PR TITLE
feat: update discord link to profile link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,20 +5,18 @@ I'm interested in game development, artificail intelligence, web development, an
 # 📫 How to reach me: 
 - [![Gmail Badge](https://img.shields.io/badge/-lapis0875@gmail.com-c14438?style=flat-square&logo=Gmail&logoColor=white&link=mailto:lapis0875@gmail.com)](mailto:lapis0875@gmail.com)
 - [![Kakao Mail Badge](https://img.shields.io/badge/-lapis0875@kakao.com-ffcd00?style=flat-square&logo=Mail.Ru&logoColor=white&link=mailto:lapis0875@kakao.com)](mailto:lapis0875@kakao.com)
-- [![Discord Badge](https://img.shields.io/badge/-lapis＃0875-7289da?style=flat-square&logo=Discord&logoColor=white&link=https://discord.com)](https://discord.com)
+- [![Discord Badge](https://img.shields.io/badge/-lapis0875＃1383-7289da?style=flat-square&logo=Discord&logoColor=white&link=https://discord.com)](https://discord.com)
 
 # 💻 Development  Languages:
 ![Python](https://img.shields.io/badge/-Python-3776ab?style=flat-square&logo=Python&logoColor=white)
 ![Java](https://img.shields.io/badge/-java-E34A86?style=flat-square&logo=java&logoColor=white)
 ![C#](https://img.shields.io/badge/-C＃-239120?style=flat-square&logo=C-Sharp)
 ![C](https://img.shields.io/badge/-C-00599C?style=flat-square&logo=C&logoColor=white)
-![Rust](https://img.shields.io/badge/-Rust-000000?style=flat-square&logo=Rust&logoColor=white)
 
 # Languages I'm currently interested in :mag:
 ![JavaScript](https://img.shields.io/badge/-JavaScript-black?style=flat-square&logo=javascript)
 ![Kotlin](https://img.shields.io/badge/-Kotlin-0095D5?style=flat-square&logo=Kotlin&logoColor=white)
-![Dart](https://img.shields.io/badge/-Dart-0175C2?style=flat-square&logo=Dart&logoColor=white)
-![Golang](https://img.shields.io/badge/-Golang-00add8?style=flat-square&logo=Go&logoColor=white)
+![Rust](https://img.shields.io/badge/-Rust-000000?style=flat-square&logo=Rust&logoColor=white)
 
 # Websites:
 I sometimes write some posts in [my tech blog](https://lapis0875.github.io) :pen:


### PR DESCRIPTION
기존 배지의 링크가 그저 discord.com으로 연결되는 문제를 해결하고자 lapis0875계정의 discord 프로필 링크로 대체했습니다.